### PR TITLE
iterkeys() not supported by dict in Python3

### DIFF
--- a/pythonKit 3.X/Checksum.py
+++ b/pythonKit 3.X/Checksum.py
@@ -66,7 +66,7 @@ def __id_generator__(size=6, chars=string.ascii_uppercase + string.digits + stri
 
 def __get_param_string__(params):
     params_string = []
-    for key in sorted(params.iterkeys()):
+    for key in sorted(params.keys()):
         value = params[key]
         params_string.append('' if value == 'null' else str(value))
     return '|'.join(params_string)


### PR DESCRIPTION
iterkeys() not supported by dictionary in Python 3 . 
Changed it to keys() , which returns an iterator implicitly.